### PR TITLE
Vcf to plink

### DIFF
--- a/R/gen_tibble.R
+++ b/R/gen_tibble.R
@@ -157,7 +157,6 @@ gen_tibble_bed_rds <- function(x, ...,
 
   bigsnp_obj <- bigsnpr::snp_attach(bigsnp_path)
 
-  #if (!("family.ID" %in% names(bigsnp_obj$fam))){
   if (all(bigsnp_obj$fam$family.ID==bigsnp_obj$fam$sample.ID)){
     indiv_meta <- list(id = bigsnp_obj$fam$sample.ID)
   } else {

--- a/R/gen_tibble.R
+++ b/R/gen_tibble.R
@@ -157,7 +157,8 @@ gen_tibble_bed_rds <- function(x, ...,
 
   bigsnp_obj <- bigsnpr::snp_attach(bigsnp_path)
 
-  if (!("family.ID" %in% names(bigsnp_obj$fam))){
+  #if (!("family.ID" %in% names(bigsnp_obj$fam))){
+  if (all(bigsnp_obj$fam$family.ID==bigsnp_obj$fam$sample.ID)){
     indiv_meta <- list(id = bigsnp_obj$fam$sample.ID)
   } else {
     indiv_meta <- list(id = bigsnp_obj$fam$sample.ID,

--- a/R/gt_as_plink.R
+++ b/R/gt_as_plink.R
@@ -4,6 +4,9 @@
 #' a PLINK bed, ped or raw file (and associated files, i.e. .bim and .fam for .bed;
 #' .fam for .ped).
 #'
+#' If the gen_tibble has been read in from vcf format, family.ID in the resulting
+#' plink files will be the same as sample.ID.
+#'
 #' @param x a [`gen_tibble`] object
 #' @param file a character string giving the path to output file. If left to NULL,
 #' the output file will have the same path and prefix of the backingfile.

--- a/R/vcf_to_fbm_cpp.R
+++ b/R/vcf_to_fbm_cpp.R
@@ -46,7 +46,7 @@ vcf_to_fbm_cpp <- function(
   code256[1:(max_ploidy+1)]<-seq(0,max_ploidy)
 
   # metadata
-  fam <- tibble(#family.ID = 0,
+  fam <- tibble(family.ID = vcf_meta$sample_names,
                 sample.ID = vcf_meta$sample_names,
                 paternal.ID = 0,
                 maternal.ID = 0,

--- a/R/vcf_to_fbm_vcfR.R
+++ b/R/vcf_to_fbm_vcfR.R
@@ -58,7 +58,7 @@ vcf_to_fbm_vcfR <- function(
   code256[1:(max_ploidy+1)]<-seq(0,max_ploidy)
 
   # metadata
-  fam <- tibble(#family.ID = 0,
+  fam <- tibble(family.ID = colnames(temp_gt),
                 sample.ID = colnames(temp_gt),
                 paternal.ID = 0,
                 maternal.ID = 0,

--- a/man/gt_as_plink.Rd
+++ b/man/gt_as_plink.Rd
@@ -24,3 +24,7 @@ This function exports all the information of a \code{gen_tibble} object into
 a PLINK bed, ped or raw file (and associated files, i.e. .bim and .fam for .bed;
 .fam for .ped).
 }
+\details{
+If the gen_tibble has been read in from vcf format, family.ID in the resulting
+plink files will be the same as sample.ID.
+}

--- a/tests/testthat/test_gen_tibble.R
+++ b/tests/testthat/test_gen_tibble.R
@@ -576,6 +576,46 @@ test_that("additional vcf tests with larger file",{
 }
 )
 
+test_that("gen_tibble family.ID from vcf",{
+
+  # If the gen_tibble has been read in from vcf format, family.ID in the resulting
+  # plink files will be the same as sample.ID.
+
+  ####  With vcfr parser
+  vcf_path <- system.file("extdata/pop_b.vcf", package = "tidypopgen")
+  pop_b_vcf_gt <- gen_tibble(vcf_path, quiet=TRUE,backingfile = tempfile(),
+                             parser="vcfR")
+
+  # write vcf_path using gt_as_plink
+  pop_b_bed <- gt_as_plink(pop_b_vcf_gt, tempfile())
+
+  # substitute ".bed" for ".fam" in pop_b_bed
+  fam_path <- gsub(".bed",".fam",pop_b_bed)
+
+  # read in the .fam file
+  fam <- read.table(fam_path, header = FALSE, stringsAsFactors = FALSE)
+
+  expect_true(all(fam$V1 == pop_b_vcf_gt$id))
+  expect_true(all(fam$V1 == fam$V2))
+
+  ####  With cpp parser
+  vcf_path <- system.file("extdata/pop_b.vcf", package = "tidypopgen")
+  pop_b_vcf_gt <- gen_tibble(vcf_path, quiet=TRUE,backingfile = tempfile(),
+                             parser="cpp")
+
+  # write vcf_path using gt_as_plink
+  pop_b_bed <- gt_as_plink(pop_b_vcf_gt, tempfile())
+
+  # substitute ".bed" for ".fam" in pop_b_bed
+  fam_path <- gsub(".bed",".fam",pop_b_bed)
+
+  # read in the .fam file
+  fam <- read.table(fam_path, header = FALSE, stringsAsFactors = FALSE)
+
+  expect_true(all(fam$V1 == pop_b_vcf_gt$id))
+  expect_true(all(fam$V1 == fam$V2))
+})
+
 
 
 # Windows prevents the deletion of the backing file. It's something to do with the memory mapping


### PR DESCRIPTION
adding family.ID back to FMB, enabling writing plink files from a gen_tibble created with a vcf