### PR TITLE
add tryCatch to gt_pca_autoSVD for roll.size error

### DIFF
--- a/R/gt_pca_autoSVD.R
+++ b/R/gt_pca_autoSVD.R
@@ -6,10 +6,13 @@
 #' [bigsnpr::snp_autoSVD()]
 #'
 #' Using gt_pca_autoSVD requires a reasonably large dataset, as the function
-#' iteratively removes regions of long range LD. If you encounter 'Error in
-#' rollmean(): Parameter 'size' is too large.' roll_size exceeds the number of
-#' variants on at least one of your chromosomes. Try reducing 'roll_size' to
+#' iteratively removes regions of long range LD. If you encounter: 'Error in
+#' rollmean(): Parameter 'size' is too large.', `roll_size` exceeds the number
+#' of variants on at least one of your chromosomes. Try reducing 'roll_size' to
 #' avoid this error.
+#'
+#' Note: rather than accessing these elements directly, it is better to use
+#' `tidy` and `augment`. See [`gt_pca_tidiers`].
 #'
 #' @param x a `gen_tbl` object
 #' @param k Number of singular vectors/values to compute. Default is `10`.
@@ -49,7 +52,7 @@
 #'   list with elements: A named list (an S3 class "big_SVD") of
 #' - `d`, the eigenvalues (singular values, i.e. as variances),
 #' - `u`, the scores for each sample on each component
-#'    (the left singular vectors)
+#'   (the left singular vectors)
 #' - `v`, the loadings (the right singular vectors)
 #' - `center`, the centering vector,
 #' - `scale`, the scaling vector,
@@ -57,17 +60,7 @@
 #' - `call`, the call that generated the object.
 #' - `loci`, the loci used after long range LD removal.
 #'
-#' Note: rather than accessing these elements directly, it is better to use
-#' `tidy` and `augment`. See [`gt_pca_tidiers`]. Note: If you encounter 'Error
-#' in rollmean(): Parameter 'size' is too large.' roll_size is exceeding the
-#' number of variants on at least one of your chromosomes. If you have
-#' pre-specified roll_size, you will need to reduce this parameter. If not, try
-#' specifying a reduced 'roll_size' to avoid this error.
-#'
 #' @export
-
-## Look at to manipulate ellipses when passing arguments
-# https://stackoverflow.com/questions/60338114/updating-values-of-three-dot-ellipsis-in-r #nolint
 
 # nolint start
 gt_pca_autoSVD <- function(

--- a/man/gt_pca_autoSVD.Rd
+++ b/man/gt_pca_autoSVD.Rd
@@ -84,13 +84,6 @@ list with elements: A named list (an S3 class "big_SVD") of
 \item \code{call}, the call that generated the object.
 \item \code{loci}, the loci used after long range LD removal.
 }
-
-Note: rather than accessing these elements directly, it is better to use
-\code{tidy} and \code{augment}. See \code{\link{gt_pca_tidiers}}. Note: If you encounter 'Error
-in rollmean(): Parameter 'size' is too large.' roll_size is exceeding the
-number of variants on at least one of your chromosomes. If you have
-pre-specified roll_size, you will need to reduce this parameter. If not, try
-specifying a reduced 'roll_size' to avoid this error.
 }
 \description{
 This function performs Principal Component Analysis on a \code{gen_tibble}, using
@@ -100,5 +93,11 @@ long-range LD regions. This function is a wrapper for
 }
 \details{
 Using gt_pca_autoSVD requires a reasonably large dataset, as the function
-iteratively removes regions of long range LD.
+iteratively removes regions of long range LD. If you encounter: 'Error in
+rollmean(): Parameter 'size' is too large.', \code{roll_size} exceeds the number
+of variants on at least one of your chromosomes. Try reducing 'roll_size' to
+avoid this error.
+
+Note: rather than accessing these elements directly, it is better to use
+\code{tidy} and \code{augment}. See \code{\link{gt_pca_tidiers}}.
 }

--- a/man/tidypopgen-package.Rd
+++ b/man/tidypopgen-package.Rd
@@ -8,12 +8,14 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-We provide a tidy grammar of population genetics, facilitating the manipulation and analysis of data on biallelic single nucleotide polymorphisms (SNPs).
+We provide a tidy grammar of population genetics, facilitating the manipulation and analysis of data on biallelic single nucleotide polymorphisms (SNPs). `tidypopgen` scales to very large genetic datasets by storing genotypes on disk, and performing operations on them in chunks, without ever loading all data in memory.
 }
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://github.com/EvolEcolGroup/tidypopgen}
   \item \url{https://evolecolgroup.github.io/tidypopgen}
+  \item Report bugs at \url{https://github.com/EvolEcolGroup/tidypopgen/issues}
 }
 
 }

--- a/tests/testthat/test_gt_pca.R
+++ b/tests/testthat/test_gt_pca.R
@@ -101,10 +101,10 @@ test_that("adjusting roll_size fixes gt_pca_autoSVD problem ", {
   )
   missing_gt <- gt_impute_simple(missing_gt, method = "mode")
 
-  # we encounter roll_size error
+  # we encounter our roll_size error
   expect_error(
     missing_pca <- missing_gt %>% gt_pca_autoSVD(verbose = FALSE),
-    "Parameter 'size' is too large."
+    "roll_size exceeds the number of variants"
   )
 
   # adjusting roll_size fixes the error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling to display clearer, more actionable error messages when the input parameter exceeds its limit.
  
- **Documentation**
  - Improved clarity in the documentation regarding error handling and usage recommendations for the `gt_pca_autoSVD` function.
  - Expanded the description of the `tidypopgen` package to include memory management and scalability details, along with new useful links for resources.

- **Tests**
  - Updated test expectations to align with the refined error messages, ensuring consistency and improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->