### PR TITLE
add error message to use gt_update_backingfile before imputing a subs…

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, run_admixture]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, dev]
   pull_request:
 
 name: lint.yaml

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, dev]
 
 name: test-coverage
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidypopgen
 Title: Tidy Population Genetics
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: 
     c(person("Evie", "Carter", role = c("aut")),
     person("Andrea", "Manica", email = "am315@cam.ac.uk", 

--- a/R/gt_impute_simple.R
+++ b/R/gt_impute_simple.R
@@ -28,8 +28,16 @@ gt_impute_simple <- function(
     on.exit(options(bigstatsr.check.parallel.blas = TRUE))
   }
 
+  if (nrow(x) != nrow(attr(x$genotypes, "bigsnp")$genotypes)) {
+    stop(
+      "The number of individuals in the gen_tibble does not match the",
+      " number of rows in the file backing matrix. Before imputing, use",
+      " gt_update_backingfile to update your file backing matrix."
+    )
+  }
+
   if (
-    !all.equal(attr(x$genotypes, "bigsnp")$genotypes$code256, bigsnpr::CODE_012)
+    !identical(attr(x$genotypes, "bigsnp")$genotypes$code256, bigsnpr::CODE_012)
   ) {
     # nolint start
     if (

--- a/tests/testthat/test_gt_impute_simple.R
+++ b/tests/testthat/test_gt_impute_simple.R
@@ -112,8 +112,10 @@ test_that("gt_impute imputes properly", {
   expect_false(any(is.na(show_genotypes(imputed_gt_mode))))
 
   # test error trying to impute an already imputed set
-  # expect_error(gt_impute_simple(imputed_gt_mode),
-  #                                 "object x is already imputed")
+  expect_error(
+    gt_impute_simple(imputed_gt_mode),
+    "object x is already imputed"
+  )
 
   # Check imputed 'mode' method
   mode_function <- function(x) {
@@ -208,6 +210,15 @@ test_that("imputing subsets", {
   test_sub <- test_sub %>% select_loci(c(3:5))
 
   # impute method = 'mode'
+  expect_error(
+    imputed_test_sub <- gt_impute_simple(test_sub, method = "mode"),
+    "The number of individuals in the gen_tibble does not match"
+  )
+
+  # update backingfile
+  suppressMessages(test_sub <- gt_update_backingfile(test_sub))
+
+  # try again
   imputed_test_sub <- gt_impute_simple(test_sub, method = "mode")
 
   # full gen_tibble does not have imputed

--- a/tests/testthat/test_gt_pca.R
+++ b/tests/testthat/test_gt_pca.R
@@ -158,6 +158,11 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
   # now extract the modern data (to be imputed)
   modern_gt <- missing_gt[-c(1:20), ]
 
+  # update the backingfiles
+  ancient_gt <- suppressMessages(gt_update_backingfile(ancient_gt))
+  modern_gt <- suppressMessages(gt_update_backingfile(modern_gt))
+
+  # impute the modern data
   modern_gt <- gt_impute_simple(modern_gt, method = "mode")
   modern_pca <- modern_gt %>% gt_pca_partialSVD()
   # if we just try to predict, we find that the new data have missing data
@@ -405,6 +410,11 @@ test_that("n_cores can be set for predict_gt_pca", {
   ancient_gt <- missing_gt[1:20, ]
   # now extract the modern data (to be imputed)
   modern_gt <- missing_gt[-c(1:20), ]
+
+  # update the backingfiles
+  ancient_gt <- suppressMessages(gt_update_backingfile(ancient_gt))
+  modern_gt <- suppressMessages(gt_update_backingfile(modern_gt))
+
   modern_gt <- gt_impute_simple(modern_gt, method = "mode")
   modern_pca <- modern_gt %>% gt_pca_partialSVD()
   expect_true(getOption("bigstatsr.check.parallel.blas"))

--- a/tests/testthat/test_gt_pca.R
+++ b/tests/testthat/test_gt_pca.R
@@ -159,8 +159,8 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
   modern_gt <- missing_gt[-c(1:20), ]
 
   # update the backingfiles
-  ancient_gt <- suppressMessages(gt_update_backingfile(ancient_gt))
-  modern_gt <- suppressMessages(gt_update_backingfile(modern_gt))
+  ancient_gt <- gt_update_backingfile(ancient_gt, quiet = TRUE)
+  modern_gt <- gt_update_backingfile(modern_gt, quiet = TRUE)
 
   # impute the modern data
   modern_gt <- gt_impute_simple(modern_gt, method = "mode")
@@ -412,8 +412,8 @@ test_that("n_cores can be set for predict_gt_pca", {
   modern_gt <- missing_gt[-c(1:20), ]
 
   # update the backingfiles
-  ancient_gt <- suppressMessages(gt_update_backingfile(ancient_gt))
-  modern_gt <- suppressMessages(gt_update_backingfile(modern_gt))
+  ancient_gt <- gt_update_backingfile(ancient_gt, quiet = TRUE)
+  modern_gt <- gt_update_backingfile(modern_gt, quiet = TRUE)
 
   modern_gt <- gt_impute_simple(modern_gt, method = "mode")
   modern_pca <- modern_gt %>% gt_pca_partialSVD()

--- a/vignettes/a02_qc.Rmd
+++ b/vignettes/a02_qc.Rmd
@@ -173,6 +173,14 @@ To explore why clumping is preferable to pruning, see <https://privefl.github.io
 
 LD clumping requires a data set with no missingness. This means we need to create an imputed data set before LD pruning, which we can do quickly with `gt_impute_simple`.
 
+Because we have removed individuals through our filtering, we first need to update the backingfiles with:
+
+```{r}
+data <- gt_update_backingfile(data)
+```
+
+And then we can impute using:
+
 ```{r}
 imputed_data <- gt_impute_simple(data, method = "random")
 ```


### PR DESCRIPTION
…et of a gt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for the imputation process to verify that input data is consistent with the expected format, with clear error messages directing users on necessary updates.
- **Tests**
	- Enhanced test cases to ensure proper error handling and data consistency checks during imputation and PCA workflows.
- **Documentation**
	- Updated guidance to include a prerequisite data update step before proceeding with imputation.
- **Chores**
	- Modified workflow configurations to include the `dev` branch for various events, enhancing the scope of automated processes.
- **Version Update**
	- Incremented the version number of the `tidypopgen` package from `0.1.0.9000` to `0.1.0.9001`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->