### PR TITLE
error message matching ID's in the bigsnp object

### DIFF
--- a/R/rbind_gen_tibble.R
+++ b/R/rbind_gen_tibble.R
@@ -90,6 +90,21 @@ rbind.gen_tbl <- function(
   if (is_pseudohaploid(ref) || is_pseudohaploid(target)) {
     any_pseudohaploid <- TRUE
   }
+  if (any(!is.na(match(ref$id, target$id)))) {
+    stop(
+      "The two gen_tibbles contain at least one individual with the",
+      " same ID."
+    )
+  }
+  if (any(!is.na(match(
+    attr(ref$genotypes, "bigsnp")$fam$sample.ID,
+    attr(target$genotypes, "bigsnp")$fam$sample.ID
+  )))) {
+    stop(
+      "The two bigsnp objects contain at least one individual with the",
+      " same ID."
+    )
+  }
   if (!quiet) {
     if (as_is) {
       if (flip_strand) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent merging genotype tables with overlapping individual IDs, ensuring users are alerted if duplicate IDs are detected.

* **Tests**
  * Introduced a new test case to verify that an error is raised when attempting to merge genotype tables with duplicate individual IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->