### PR TITLE
allow >2 components in lsq projection for pca

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidypopgen
 Title: Tidy Population Genetics
-Version: 0.4.1.9002
+Version: 0.4.1.9003
 Authors@R: 
     c(person("Evie", "Carter", role = c("aut")),
     person("Eirlys", "Tysall", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tidypopgen dev
+* allow least squares projection of multiple components at once in
+  `gt_project_pca()`
+
 # tidypopgen 0.4.1
 * duplicate-distance checks removed in `is_loci_table_ordered()`
 * make `qc_report_*` functions work with pseudohaploids

--- a/R/predict_gt_pca.R
+++ b/R/predict_gt_pca.R
@@ -8,9 +8,10 @@
 #' @param project_method a string taking the value of either "simple", "OADP"
 #'   (Online Augmentation, Decomposition, and Procrustes (OADP) projection), or
 #'   "least_squares" (as done by SMARTPCA)
-#' @param lsq_pcs a vector of the values of the two principal
+#' @param lsq_pcs a vector of the values of the principal
 #' components to use for the least square fitting. Only relevant
-#' if`project_method = 'least_squares'`
+#' if `project_method = 'least_squares'`. It defaults to the first two
+#' components.
 #' @param block_size number of loci read simultaneously (larger values will
 #' speed up computation, but require more memory)
 #' @param n_cores number of cores
@@ -71,19 +72,20 @@
 #'
 # this is a modified version of bigstatsr::predict.big_SVD
 predict.gt_pca <- function(
-    object,
-    new_data = NULL,
-    project_method = c(
-      "none",
-      "simple",
-      "OADP",
-      "least_squares"
-    ),
-    lsq_pcs = c(1, 2),
-    block_size = NULL,
-    n_cores = 1,
-    as_matrix = TRUE,
-    ...) {
+  object,
+  new_data = NULL,
+  project_method = c(
+    "none",
+    "simple",
+    "OADP",
+    "least_squares"
+  ),
+  lsq_pcs = c(1, 2),
+  block_size = NULL,
+  n_cores = 1,
+  as_matrix = TRUE,
+  ...
+) {
   if (n_cores > 1) {
     # Remove checking for two levels of parallelism
     .old_opt <- getOption("bigstatsr.check.parallel.blas", TRUE)
@@ -183,10 +185,15 @@ predict.gt_pca <- function(
         return(output)
       }
     } else if (project_method == "least_squares") {
-      if (any(lsq_pcs > ncol(object$v))) {
+      if (
+          length(lsq_pcs) == 0 ||
+            any(lsq_pcs < 1) ||
+            any(lsq_pcs > ncol(object$v)) ||
+            !all(lsq_pcs == as.integer(lsq_pcs))) {
         stop(
-          "lsq_pcs should include two components that were computed",
-          "for the object, e.g. c(1,2)"
+          "lsq_pcs should be a vector of valid component indices ",
+          "(positive integers between 1 and ", ncol(object$v), "), ",
+          "e.g., c(1, 2) or c(1, 2, 3)"
         )
       }
       X <- .gt_get_fbm(new_data) # pointer for FBM #nolint
@@ -234,15 +241,16 @@ output_type <- function(object, as_matrix, id) {
 # a port of bigsnpr::part_prod to work on standard fb256 matrices
 
 fbm256_part_prod <- function(
-    X,
-    ind,
-    ind.row,
-    ind.col,
-    center, # nolint
-    scale,
-    V,
-    XV,
-    X_norm) {
+  X,
+  ind,
+  ind.row,
+  ind.col,
+  center, # nolint
+  scale,
+  V,
+  XV,
+  X_norm
+) {
   # nolint
   res <- fbm256_prod_and_rowSumsSq(
     BM = X,

--- a/R/predict_gt_pca.R
+++ b/R/predict_gt_pca.R
@@ -196,6 +196,10 @@ predict.gt_pca <- function(
           "e.g., c(1, 2) or c(1, 2, 3)"
         )
       }
+      # test that components are unique (i.e. no duplicates)
+      if (any(duplicated(lsq_pcs))) {
+        stop("lsq_pcs should not contain duplicate values")
+      }
       X <- .gt_get_fbm(new_data) # pointer for FBM #nolint
       proj_i <- NULL # hack to define iterator
       lsq_proj <- foreach::foreach(

--- a/R/predict_gt_pca.R
+++ b/R/predict_gt_pca.R
@@ -8,7 +8,7 @@
 #' @param project_method a string taking the value of either "simple", "OADP"
 #'   (Online Augmentation, Decomposition, and Procrustes (OADP) projection), or
 #'   "least_squares" (as done by SMARTPCA)
-#' @param lsq_pcs a vector of length two with the values of the two principal
+#' @param lsq_pcs a vector of the values of the two principal
 #' components to use for the least square fitting. Only relevant
 #' if`project_method = 'least_squares'`
 #' @param block_size number of loci read simultaneously (larger values will
@@ -60,7 +60,7 @@
 #' # Predict with least squares
 #' predict(pca,
 #'   new_data = new_lobsters,
-#'   project_method = "least_squares", lsq_pcs = c(1, 2)
+#'   project_method = "least_squares", lsq_pcs = c(1, 2, 3)
 #' )
 #'
 #' # Return a tibble
@@ -183,7 +183,7 @@ predict.gt_pca <- function(
         return(output)
       }
     } else if (project_method == "least_squares") {
-      if (length(lsq_pcs) != 2 || any(lsq_pcs > ncol(object$v))) {
+      if (any(lsq_pcs > ncol(object$v))) {
         stop(
           "lsq_pcs should include two components that were computed",
           "for the object, e.g. c(1,2)"

--- a/R/predict_gt_pca.R
+++ b/R/predict_gt_pca.R
@@ -8,7 +8,7 @@
 #' @param project_method a string taking the value of either "simple", "OADP"
 #'   (Online Augmentation, Decomposition, and Procrustes (OADP) projection), or
 #'   "least_squares" (as done by SMARTPCA)
-#' @param lsq_pcs a vector of the values of the principal
+#' @param lsq_pcs a vector of the indices of the principal
 #' components to use for the least square fitting. Only relevant
 #' if `project_method = 'least_squares'`. It defaults to the first two
 #' components.
@@ -187,6 +187,7 @@ predict.gt_pca <- function(
     } else if (project_method == "least_squares") {
       if (
           length(lsq_pcs) == 0 ||
+            anyNA(lsq_pcs) ||
             any(lsq_pcs < 1) ||
             any(lsq_pcs > ncol(object$v)) ||
             !all(lsq_pcs == as.integer(lsq_pcs))) {

--- a/man/predict_gt_pca.Rd
+++ b/man/predict_gt_pca.Rd
@@ -24,7 +24,7 @@
 (Online Augmentation, Decomposition, and Procrustes (OADP) projection), or
 "least_squares" (as done by SMARTPCA)}
 
-\item{lsq_pcs}{a vector of length two with the values of the two principal
+\item{lsq_pcs}{a vector of the values of the two principal
 components to use for the least square fitting. Only relevant
 if\code{project_method = 'least_squares'}}
 
@@ -83,7 +83,7 @@ predict(pca, new_data = new_lobsters, project_method = "OADP")
 # Predict with least squares
 predict(pca,
   new_data = new_lobsters,
-  project_method = "least_squares", lsq_pcs = c(1, 2)
+  project_method = "least_squares", lsq_pcs = c(1, 2, 3)
 )
 
 # Return a tibble

--- a/man/predict_gt_pca.Rd
+++ b/man/predict_gt_pca.Rd
@@ -24,7 +24,7 @@
 (Online Augmentation, Decomposition, and Procrustes (OADP) projection), or
 "least_squares" (as done by SMARTPCA)}
 
-\item{lsq_pcs}{a vector of the values of the two principal
+\item{lsq_pcs}{a vector of the values of the principal
 components to use for the least square fitting. Only relevant
 if\code{project_method = 'least_squares'}}
 

--- a/man/predict_gt_pca.Rd
+++ b/man/predict_gt_pca.Rd
@@ -24,9 +24,10 @@
 (Online Augmentation, Decomposition, and Procrustes (OADP) projection), or
 "least_squares" (as done by SMARTPCA)}
 
-\item{lsq_pcs}{a vector of the values of the principal
+\item{lsq_pcs}{a vector of the indices of the principal
 components to use for the least square fitting. Only relevant
-if\code{project_method = 'least_squares'}}
+if \code{project_method = 'least_squares'}. It defaults to the first two
+components.}
 
 \item{block_size}{number of loci read simultaneously (larger values will
 speed up computation, but require more memory)}

--- a/tests/testthat/test_gt_pca.R
+++ b/tests/testthat/test_gt_pca.R
@@ -203,6 +203,25 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
   )
   expect_true(all(dim(lsq_pred_tbl) == c(20, 3)))
   expect_true(inherits(lsq_pred_tbl, "tbl_df"))
+
+  # test errors from incorrect lsq_pcs
+  expect_error(
+    predict(
+      modern_pca,
+      new_data = ancient_gt,
+      project_method = "least_squares",
+      lsq_pcs = c(0, 2)
+    ),    "lsq_pcs should be a vector of valid"
+  )
+  expect_error(
+    predict(
+      modern_pca,
+      new_data = ancient_gt,
+      project_method = "least_squares",
+      lsq_pcs = c(1, 20)
+    ),    "lsq_pcs should be a vector of valid"
+  )
+
 })
 
 test_that("PCA functions work with loci out of order", {

--- a/tests/testthat/test_gt_pca.R
+++ b/tests/testthat/test_gt_pca.R
@@ -204,6 +204,16 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
   expect_true(all(dim(lsq_pred_tbl) == c(20, 3)))
   expect_true(inherits(lsq_pred_tbl, "tbl_df"))
 
+  # test 3 components
+  multi_comp_pred <- predict(
+    modern_pca,
+    new_data = ancient_gt,
+    project_method = "least_squares",
+    lsq_pcs = c(1, 2, 3),
+    as_matrix = TRUE
+  )
+  expect_true(all(dim(multi_comp_pred) == c(20, 3)))
+
   # test errors from incorrect lsq_pcs
   expect_error(
     predict(
@@ -211,7 +221,7 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
       new_data = ancient_gt,
       project_method = "least_squares",
       lsq_pcs = c(0, 2)
-    ),    "lsq_pcs should be a vector of valid"
+    ), "lsq_pcs should be a vector of valid"
   )
   expect_error(
     predict(
@@ -219,9 +229,8 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
       new_data = ancient_gt,
       project_method = "least_squares",
       lsq_pcs = c(1, 20)
-    ),    "lsq_pcs should be a vector of valid"
+    ), "lsq_pcs should be a vector of valid"
   )
-
 })
 
 test_that("PCA functions work with loci out of order", {

--- a/tests/testthat/test_gt_pca.R
+++ b/tests/testthat/test_gt_pca.R
@@ -231,6 +231,45 @@ test_that("fit_gt_pca_and_predict_splitted_data", {
       lsq_pcs = c(1, 20)
     ), "lsq_pcs should be a vector of valid"
   )
+
+  # Test empty vector
+  expect_error(
+    predict(
+      modern_pca,
+      new_data = ancient_gt,
+      project_method = "least_squares",
+      lsq_pcs = c()
+    ), "lsq_pcs should be a vector of valid"
+  )
+
+  # Test duplicate components
+  expect_error(multi_comp_dup <- predict(
+    modern_pca,
+    new_data = ancient_gt,
+    project_method = "least_squares",
+    lsq_pcs = c(1, 1, 2),
+    as_matrix = TRUE
+  ), "lsq_pcs should not contain duplicate values")
+
+  # Test single component
+  single_comp <- predict(
+    modern_pca,
+    new_data = ancient_gt,
+    project_method = "least_squares",
+    lsq_pcs = 1,
+    as_matrix = TRUE
+  )
+  expect_true(all(dim(single_comp) == c(20, 1)))
+
+  # Test all components
+  all_comp <- predict(
+    modern_pca,
+    new_data = ancient_gt,
+    project_method = "least_squares",
+    lsq_pcs = 1:10,
+    as_matrix = TRUE
+  )
+  expect_true(all(dim(all_comp) == c(20, 10)))
 })
 
 test_that("PCA functions work with loci out of order", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Least-squares projection now supports projecting multiple principal components (not limited to two).

* **Documentation**
  * Parameter descriptions and examples updated to reflect multi-component least-squares projection.

* **Tests**
  * Added tests for multi-component least-squares projection and for invalid component index inputs.

* **Chores**
  * Development version bumped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->