### PR TITLE
Document monomorphic error across all gt_pca pages

### DIFF
--- a/R/gt_pca_autoSVD.R
+++ b/R/gt_pca_autoSVD.R
@@ -14,6 +14,10 @@
 #' Note: rather than accessing these elements directly, it is better to use
 #' `tidy` and `augment`. See [`gt_pca_tidiers`].
 #'
+#' NOTE: monomorphic markers must be removed before PCA is computed. The error
+#' message 'Error: some variables have zero scaling; remove them before
+#' attempting to scale.' indicates that monomorphic markers are present.
+#'
 #' @param x a `gen_tbl` object
 #' @param k Number of singular vectors/values to compute. Default is `10`.
 #'   **This algorithm should be used to compute a few singular vectors/values.**

--- a/R/gt_pca_partialSVD.R
+++ b/R/gt_pca_partialSVD.R
@@ -6,6 +6,10 @@
 #' otherwise, [gt_pca_randomSVD()] is a better option. This function is a
 #' wrapper for [bigstatsr::big_SVD()].
 #'
+#' NOTE: monomorphic markers must be removed before PCA is computed. The error
+#' message 'Error: some variables have zero scaling; remove them before
+#' attempting to scale.' indicates that monomorphic markers are present.
+#'
 #' @param x a `gen_tbl` object
 #' @param k Number of singular vectors/values to compute. Default is `10`.
 #'   **This algorithm should be used to compute a few singular vectors/values.**

--- a/R/gt_pca_randomSVD.R
+++ b/R/gt_pca_randomSVD.R
@@ -8,6 +8,10 @@
 #' This function is a wrapper
 #' for [bigstatsr::big_randomSVD()]
 #'
+#' NOTE: monomorphic markers must be removed before PCA is computed. The error
+#' message 'Error: some variables have zero scaling; remove them before
+#' attempting to scale.' indicates that monomorphic markers are present.
+#'
 #' @param x a `gen_tibble` object
 #' @param k Number of singular vectors/values to compute. Default is `10`.
 #'   **This algorithm should be used to compute a few singular vectors/values.**

--- a/man/gt_pca_autoSVD.Rd
+++ b/man/gt_pca_autoSVD.Rd
@@ -100,6 +100,10 @@ avoid this error.
 
 Note: rather than accessing these elements directly, it is better to use
 \code{tidy} and \code{augment}. See \code{\link{gt_pca_tidiers}}.
+
+NOTE: monomorphic markers must be removed before PCA is computed. The error
+message 'Error: some variables have zero scaling; remove them before
+attempting to scale.' indicates that monomorphic markers are present.
 }
 \examples{
 \dontshow{if (all(rlang::is_installed(c("RhpcBLASctl", "data.table")))) withAutoprint(\{ # examplesIf}

--- a/man/gt_pca_partialSVD.Rd
+++ b/man/gt_pca_partialSVD.Rd
@@ -54,6 +54,11 @@ if the number of individuals is much smaller than the number of loci;
 otherwise, \code{\link[=gt_pca_randomSVD]{gt_pca_randomSVD()}} is a better option. This function is a
 wrapper for \code{\link[bigstatsr:big_SVD]{bigstatsr::big_SVD()}}.
 }
+\details{
+NOTE: monomorphic markers must be removed before PCA is computed. The error
+message 'Error: some variables have zero scaling; remove them before
+attempting to scale.' indicates that monomorphic markers are present.
+}
 \examples{
 # Create a gen_tibble of lobster genotypes
 bed_file <-

--- a/man/gt_pca_randomSVD.Rd
+++ b/man/gt_pca_randomSVD.Rd
@@ -79,6 +79,11 @@ memory-efficient. Thus, it can be used on very large big.matrices.
 This function is a wrapper
 for \code{\link[bigstatsr:big_randomSVD]{bigstatsr::big_randomSVD()}}
 }
+\details{
+NOTE: monomorphic markers must be removed before PCA is computed. The error
+message 'Error: some variables have zero scaling; remove them before
+attempting to scale.' indicates that monomorphic markers are present.
+}
 \examples{
 \dontshow{if (all(rlang::is_installed(c("RhpcBLASctl", "data.table")))) withAutoprint(\{ # examplesIf}
 \dontshow{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for PCA functions to clarify the requirement of removing monomorphic markers before computation
  * Added explanations for error messages related to variable scaling, helping users troubleshoot PCA issues more effectively

<!-- end of auto-generated comment: release notes by coderabbit.ai -->