### PR TITLE
fix gt_admixture to normalise relative path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidypopgen
 Title: Tidy Population Genetics
-Version: 0.4.3.9002
+Version: 0.4.3.9003
 Authors@R: 
     c(person("Evie", "Carter", role = c("aut")),
     person("Eirlys", "Tysall", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
   sample information
 * fix `loci_` functions output when calculating across groups for a single loci
 * add `outdir` argument to `gt_admixture()`
+* fix `outdir` argument in `gt_admixture()` to use relative paths
+* fix `gt_admixture()` output file names when n_runs > 1
 
 # tidypopgen 0.4.3
 * fix occasional test failure when temporary file names contained

--- a/R/gen_tibble_bed.R
+++ b/R/gen_tibble_bed.R
@@ -1,13 +1,12 @@
 gen_tibble_bed_rds <- function(
-  x,
-  ...,
-  ploidy = 2,
-  valid_alleles = c("A", "T", "C", "G"),
-  missing_alleles = c("0", "."),
-  allow_duplicates = FALSE,
-  backingfile = NULL,
-  quiet = FALSE
-) {
+    x,
+    ...,
+    ploidy = 2,
+    valid_alleles = c("A", "T", "C", "G"),
+    missing_alleles = c("0", "."),
+    allow_duplicates = FALSE,
+    backingfile = NULL,
+    quiet = FALSE) {
   # if file ends in bed
   if (grepl("\\.bed$", x)) {
     # check that the bim and fam files exist

--- a/R/gt_admixture.R
+++ b/R/gt_admixture.R
@@ -221,6 +221,27 @@ gt_admixture <- function(
         stop(adm_out)
       }
 
+      # rename the file to include the repeat number
+      file.rename(
+        q_file,
+        file.path(outdir, paste0(
+          gsub(".bed$", "", basename(input_file)),
+          ".", this_k, ".rep", this_rep, ".Q"
+        ))
+      )
+      p_file <- file.path(outdir, paste0(
+        gsub(".bed$", "", basename(input_file)),
+        ".", this_k, ".P"
+      ))
+      file.rename(
+        p_file,
+        file.path(outdir, paste0(
+          gsub(".bed$", "", basename(input_file)),
+          ".", this_k, ".rep", this_rep, ".P"
+        ))
+      )
+
+
       # read the output
       output_prefix <- file.path(
         outdir,
@@ -232,11 +253,11 @@ gt_admixture <- function(
       adm_list$k[index] <- this_k
       adm_list$Q[[index]] <-
         q_matrix(utils::read.table(
-          paste(output_prefix, this_k, "Q", sep = "."),
+          paste(output_prefix, this_k, paste0("rep", this_rep), "Q", sep = "."),
           header = FALSE
         ))
       adm_list$P[[index]] <- utils::read.table(
-        paste(output_prefix, this_k, "P", sep = "."),
+        paste(output_prefix, this_k, paste0("rep", this_rep), "P", sep = "."),
         header = FALSE
       ) # nolint
       adm_list$loglik[index] <- as.numeric(strsplit(

--- a/R/gt_admixture.R
+++ b/R/gt_admixture.R
@@ -222,25 +222,34 @@ gt_admixture <- function(
       }
 
       # rename the file to include the repeat number
-      file.rename(
-        q_file,
-        file.path(outdir, paste0(
-          gsub(".bed$", "", basename(input_file)),
-          ".", this_k, ".rep", this_rep, ".Q"
-        ))
-      )
+      q_file_renamed <- file.path(outdir, paste0(
+        gsub(".bed$", "", basename(input_file)),
+        ".", this_k, ".rep", this_rep, ".Q"
+      ))
+      if (!file.rename(q_file, q_file_renamed)) {
+        stop(
+          "Failed to rename ADMIXTURE Q file from '", q_file,
+          "' to '", q_file_renamed,
+          "'. Check that ADMIXTURE completed successfully and that you have ",
+          "write permissions for the output directory '", outdir, "'."
+        )
+      }
       p_file <- file.path(outdir, paste0(
         gsub(".bed$", "", basename(input_file)),
         ".", this_k, ".P"
       ))
-      file.rename(
-        p_file,
-        file.path(outdir, paste0(
-          gsub(".bed$", "", basename(input_file)),
-          ".", this_k, ".rep", this_rep, ".P"
-        ))
-      )
-
+      p_file_renamed <- file.path(outdir, paste0(
+        gsub(".bed$", "", basename(input_file)),
+        ".", this_k, ".rep", this_rep, ".P"
+      ))
+      if (!file.rename(p_file, p_file_renamed)) {
+        stop(
+          "Failed to rename ADMIXTURE P file from '", p_file,
+          "' to '", p_file_renamed,
+          "'. Check that ADMIXTURE completed successfully and that you have ",
+          "write permissions for the output directory '", outdir, "'."
+        )
+      }
 
       # read the output
       output_prefix <- file.path(

--- a/R/gt_admixture.R
+++ b/R/gt_admixture.R
@@ -157,6 +157,7 @@ gt_admixture <- function(
       stop("The directory ", outdir, " does not exist.")
     }
   }
+  outdir <- normalizePath(outdir)
   # store working directory
   wd <- getwd()
   # change to the directory of the input file
@@ -227,6 +228,7 @@ gt_admixture <- function(
           fixed = TRUE
         )
       )
+
       adm_list$k[index] <- this_k
       adm_list$Q[[index]] <-
         q_matrix(utils::read.table(

--- a/tests/testthat/test_gt_admixture.R
+++ b/tests/testthat/test_gt_admixture.R
@@ -547,6 +547,9 @@ test_that("grouping before running gt_admxiture vs reordering after running gt_a
 })
 
 test_that("set output dir for admixture Q files", {
+  directory <- getwd()
+  on.exit(setwd(directory))
+
   anole_plink <- gt_as_plink(
     anole_gt,
     file = tempfile(),
@@ -579,4 +582,31 @@ test_that("set output dir for admixture Q files", {
     seed = 123,
     outdir = "blah",
   ), "does not exist")
+
+  # create a second temporary directory
+  test_dir2 <- paste0(tempdir(), "adm_qmat2")
+  # create two folders inside this directory
+  dir.create(test_dir2)
+  dir.create(paste0(test_dir2, "/folder1"))
+  dir.create(paste0(test_dir2, "/folder2"))
+  # set wd to folder1
+  old_wd <- getwd()
+  setwd(paste0(test_dir2, "/folder1"))
+  # create a relative path string to folder2
+  relative_path <- "../folder2"
+
+  # now check with a relative path and multiple runs
+  adm_res2 <- gt_admixture(
+    x = anole_plink,
+    n_runs = 2,
+    k = c(3:4),
+    crossval = FALSE,
+    n_cores = 1,
+    seed = c(123, 456),
+    outdir = relative_path,
+  )
+
+  # check we get 2 files, a .Q and a .P in the relative path
+  expect_equal(length(list.files(relative_path)), 8)
+  expect_true(all(grepl("\\.Q$|\\.P$", list.files(relative_path))))
 })

--- a/tests/testthat/test_gt_admixture.R
+++ b/tests/testthat/test_gt_admixture.R
@@ -557,7 +557,7 @@ test_that("set output dir for admixture Q files", {
   )
 
   # create a tempdir
-  test_dir <- paste0(tempdir(), "adm_qmat")
+  test_dir <- file.path(tempdir(), "adm_qmat")
   dir.create(test_dir)
 
   adm_res <- gt_admixture(
@@ -584,14 +584,16 @@ test_that("set output dir for admixture Q files", {
   ), "does not exist")
 
   # create a second temporary directory
-  test_dir2 <- paste0(tempdir(), "adm_qmat2")
+  test_dir2 <- file.path(tempdir(), "adm_qmat2")
   # create two folders inside this directory
   dir.create(test_dir2)
-  dir.create(paste0(test_dir2, "/folder1"))
-  dir.create(paste0(test_dir2, "/folder2"))
+  dir.create(file.path(test_dir2, "/folder1"))
+  dir.create(file.path(test_dir2, "/folder2"))
   # set wd to folder1
   old_wd <- getwd()
-  setwd(paste0(test_dir2, "/folder1"))
+  on.exit(setwd(old_wd), add = TRUE)
+  on.exit(unlink(test_dir2, recursive = TRUE), add = TRUE)
+  setwd(file.path(test_dir2, "/folder1"))
   # create a relative path string to folder2
   relative_path <- "../folder2"
 
@@ -606,7 +608,7 @@ test_that("set output dir for admixture Q files", {
     outdir = relative_path,
   )
 
-  # check we get 2 files, a .Q and a .P in the relative path
+  # check we get 8 files, a .Q and a .P in the relative path
   expect_equal(length(list.files(relative_path)), 8)
   expect_true(all(grepl("\\.Q$|\\.P$", list.files(relative_path))))
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize output directory handling and add per-run suffixes to repeated-run output files to avoid collisions and ensure consistent I/O.
* **Tests**
  * Expanded tests for relative output directories, multiple runs, expected file counts/names, and working-directory restoration/cleanup.
* **Style**
  * Adjusted public function parameter formatting (no behavioral change).
* **Chores**
  * Bumped package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->