### PR TITLE
fix saving .rds file, gen_tbl from vcf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Suggests:
     knitr,
     detectRUNS,
     LEA,
+    pcadapt,
     RhpcBLASctl,
     rmarkdown,
     rnaturalearth,

--- a/R/gen_tibble.R
+++ b/R/gen_tibble.R
@@ -204,6 +204,7 @@ gen_tibble.character <-
         allow_duplicates = allow_duplicates,
         quiet = quiet
       )
+      gt_save(x_gt, quiet = quiet) # nolint
     } else if (tolower(file_ext(x)) == "ped") {
       x_gt <- gen_tibble_ped(
         x = x,

--- a/R/gen_tibble.R
+++ b/R/gen_tibble.R
@@ -174,6 +174,8 @@ gen_tibble.character <-
     # normalise path
     x <- normalizePath(x, mustWork = FALSE)
 
+    save_full <- FALSE
+
     if ((tolower(file_ext(x)) == "bed") || (tolower(file_ext(x)) == "rds")) {
       rlang::check_dots_empty()
       x_gt <- gen_tibble_bed_rds(
@@ -204,7 +206,7 @@ gen_tibble.character <-
         allow_duplicates = allow_duplicates,
         quiet = quiet
       )
-      gt_save(x_gt, quiet = quiet) # nolint
+      save_full <- TRUE
     } else if (tolower(file_ext(x)) == "ped") {
       x_gt <- gen_tibble_ped(
         x = x,
@@ -261,7 +263,11 @@ gen_tibble.character <-
       }
     }
 
-    gt_save_light(x_gt, quiet = quiet) # nolint
+    if (save_full) {
+      gt_save(x_gt, quiet = quiet) # nolint
+    } else {
+      gt_save_light(x_gt, quiet = quiet) # nolint
+    }
     return(x_gt)
   }
 

--- a/man/gt_update_backingfile.Rd
+++ b/man/gt_update_backingfile.Rd
@@ -18,7 +18,7 @@ gt_update_backingfile(
 \item{backingfile}{the path, including the file name without extension, for
 backing files used to store the data (they will be given a .bk and .rds
 automatically). If left to NULL (the default), the file name will be based
-on the name f the current backing file.}
+on the name of the current backing file.}
 
 \item{chunk_size}{the number of loci to process at once}
 

--- a/tests/testthat/test_gen_tibble_vcf.R
+++ b/tests/testthat/test_gen_tibble_vcf.R
@@ -42,6 +42,9 @@ if (rlang::is_installed("vcfR")) {
       backingfile = tempfile(),
       parser = "vcfR"
     )
+    expect_true(file.exists(gt_get_file_names(pop_b_vcf_gt)[1]))
+    expect_true(file.exists(gt_get_file_names(pop_b_vcf_gt)[2]))
+
     expect_true(all.equal(
       show_genotypes(pop_b_gt),
       show_genotypes(pop_b_vcf_gt)
@@ -78,6 +81,9 @@ if (rlang::is_installed("vcfR")) {
         backingfile = tempfile(),
         parser = "cpp"
       )
+
+    expect_true(file.exists(gt_get_file_names(pop_b_vcf_fast_gt)[1]))
+    expect_true(file.exists(gt_get_file_names(pop_b_vcf_fast_gt)[2]))
 
     expect_error(
       gen_tibble(vcf_path,

--- a/tests/testthat/test_gt_pcadapt.R
+++ b/tests/testthat/test_gt_pcadapt.R
@@ -20,10 +20,10 @@ test_that("n_cores can be set", {
   expect_true(getOption("bigstatsr.check.parallel.blas"))
 })
 
-test_that("gt_pcadapt on gen_tbl vcf",{
+test_that("gt_pcadapt 'U' error with heavily imputed SNPs", {
   vcf_path <-
     system.file("/extdata/anolis/punctatus_t70_s10_n46_filtered.recode.vcf.gz",
-                package = "tidypopgen"
+      package = "tidypopgen"
     )
   anolis <- gen_tibble(
     vcf_path,
@@ -31,15 +31,65 @@ test_that("gt_pcadapt on gen_tbl vcf",{
     backingfile = tempfile(),
     parser = "vcfR"
   )
+  # remove monomorphic SNPs
+  anolis <- anolis %>% select_loci_if(loci_maf(genotypes) > 0.3)
+  # update backingfile
+  anolis <- gt_update_backingfile(anolis, quiet = TRUE)
+  # impute
   anolis <- gt_impute_simple(anolis, method = "mode")
-  anolis <- anolis %>% select_loci_if(loci_maf(genotypes) > 0)
-  anolis <- gt_update_backingfile(anolis)
-
-  dim(.gt_get_fbm(anolis))
-  gt_uses_imputed(anolis)
-  gt_has_imputed(anolis)
+  # set imputed to TRUE (just to be sure)
   gt_set_imputed(anolis, TRUE)
+  # test pca
+  anolis_pca <- gt_pca_randomSVD(anolis)
+  # fails in gt_pcadapt
+  expect_error(
+    gt_pcadapt(anolis, anolis_pca, k = 2),
+    "You can't have missing values in 'U'"
+  )
 
-  pop_b_vcf_pca <- gt_pca_randomSVD(anolis)
-  pop_b_vcf_pcadapt <- gt_pcadapt(anolis, pop_b_vcf_pca, k = 2)
+  # double check our data is imputed (no missingness)
+  expect_true(gt_has_imputed(anolis))
+  expect_true(inherits(attributes(anolis$genotypes)$fbm, "FBM.code256"))
+  # double check the pca scores do not contain NA's
+  expect_false(any(is.na(anolis_pca$u)))
+
+  # Now we write the same data out as a bed file
+  path <- file.path(tempdir(), "anolis_plink")
+  gt_as_plink(anolis, file = path)
+  library(pcadapt)
+  filename <- read.pcadapt(paste0(path, ".bed"), type = "bed")
+  # and pcadapt works on this bed file
+  # (although, this uses pcadapt, while our function uses snp_pcadapt)
+  x <- pcadapt(input = filename, K = 2)
+  expect_true(inherits(x, "pcadapt"))
+
+  # next, we used bigsnpr:::multiLinReg directly to generate the tscores object
+  # this shows that NA's are introduced
+  # we find NA-causing SNPs from tscores
+  # [1]   36   85  182  184  197  265  381  411  471  472  473  530  576  706
+  # 713  762  823  846  854  855  856
+  # [22]  873  878  886 1002 1073 1081
+  # and write these as a vector to remove
+  snps_to_remove <- c(
+    36, 85, 182, 184, 197, 265, 381, 411, 471, 472, 473, 530, 576, 706,
+    713, 762, 823, 846, 854, 855, 856,
+    873, 878, 886, 1002, 1073, 1081
+  )
+  anolis_bad_snps <- anolis %>% select_loci(all_of(snps_to_remove))
+  # all of these SNPs have a MAF of 0.5 (imputed)
+  loci_maf(anolis_bad_snps)
+  gt_set_imputed(anolis_bad_snps, TRUE)
+  show_genotypes(anolis_bad_snps)
+
+  # remove these SNPs
+  anolis <- anolis %>% select_loci(-all_of(snps_to_remove))
+  # check MAF is sensible
+  loci_maf(anolis)
+  # update backingfile
+  anolis <- gt_update_backingfile(anolis, quiet = TRUE)
+  # test pca
+  anolis_pca <- gt_pca_randomSVD(anolis)
+  # and now it works
+  anolis_pcadapt <- gt_pcadapt(anolis, anolis_pca, k = 2)
+  expect_true(inherits(anolis_pcadapt, "gt_pcadapt"))
 })

--- a/tests/testthat/test_gt_pcadapt.R
+++ b/tests/testthat/test_gt_pcadapt.R
@@ -34,6 +34,12 @@ test_that("gt_pcadapt on gen_tbl vcf",{
   anolis <- gt_impute_simple(anolis, method = "mode")
   anolis <- anolis %>% select_loci_if(loci_maf(genotypes) > 0)
   anolis <- gt_update_backingfile(anolis)
+
+  dim(.gt_get_fbm(anolis))
+  gt_uses_imputed(anolis)
+  gt_has_imputed(anolis)
+  gt_set_imputed(anolis, TRUE)
+
   pop_b_vcf_pca <- gt_pca_randomSVD(anolis)
   pop_b_vcf_pcadapt <- gt_pcadapt(anolis, pop_b_vcf_pca, k = 2)
 })

--- a/tests/testthat/test_gt_pcadapt.R
+++ b/tests/testthat/test_gt_pcadapt.R
@@ -19,3 +19,21 @@ test_that("n_cores can be set", {
   two_core <- gt_pcadapt(missing_gt, missing_pca, k = 3, n_cores = 2)
   expect_true(getOption("bigstatsr.check.parallel.blas"))
 })
+
+test_that("gt_pcadapt on gen_tbl vcf",{
+  vcf_path <-
+    system.file("/extdata/anolis/punctatus_t70_s10_n46_filtered.recode.vcf.gz",
+                package = "tidypopgen"
+    )
+  anolis <- gen_tibble(
+    vcf_path,
+    quiet = TRUE,
+    backingfile = tempfile(),
+    parser = "vcfR"
+  )
+  anolis <- gt_impute_simple(anolis, method = "mode")
+  anolis <- anolis %>% select_loci_if(loci_maf(genotypes) > 0)
+  anolis <- gt_update_backingfile(anolis)
+  pop_b_vcf_pca <- gt_pca_randomSVD(anolis)
+  pop_b_vcf_pcadapt <- gt_pcadapt(anolis, pop_b_vcf_pca, k = 2)
+})

--- a/tests/testthat/test_gt_pcadapt.R
+++ b/tests/testthat/test_gt_pcadapt.R
@@ -20,6 +20,8 @@ test_that("n_cores can be set", {
   expect_true(getOption("bigstatsr.check.parallel.blas"))
 })
 
+skip_if_not_installed("pcadapt")
+
 test_that("gt_pcadapt 'U' error with heavily imputed SNPs", {
   vcf_path <-
     system.file("/extdata/anolis/punctatus_t70_s10_n46_filtered.recode.vcf.gz",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence for VCF-backed tibble creation so full backing files are saved when applicable, preventing incomplete saves.

* **Tests**
  * Added tests that verify backing files are actually created on disk for VCF-backed workflows.
  * Added a regression test covering PCA-based analysis failure and recovery when heavy imputation causes errors, including export/import flow verification to ensure analyses succeed after problematic sites are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->